### PR TITLE
[FE] 로그아웃 api 분리

### DIFF
--- a/client/src/api/logout.api.js
+++ b/client/src/api/logout.api.js
@@ -1,0 +1,18 @@
+import axios from 'axios';
+
+const logout = async (accessToken) => {
+  try {
+
+    const response = await axios.delete("/api/logouts", {
+      headers: {
+        Authorization: accessToken,
+      },
+    });
+    return response;
+  } catch (error) {
+    console.log(error);
+    throw error.response.status;
+  }
+};
+
+export default logout;

--- a/client/src/components/Header/Header.jsx
+++ b/client/src/components/Header/Header.jsx
@@ -6,12 +6,15 @@ import UserAvatar from "../../assets/userAvarta.png";
 import { HiMiniMoon } from "react-icons/hi2";
 import { MdOutlineLogout } from "react-icons/md";
 import { TiWeatherPartlySunny } from "react-icons/ti";
-import axios from "axios";
+import useAccessTokenStore from "../../store/store.accessToken";
+import logout from "../../api/logout.api";
 
 const Header = () => {
   const navigate = useNavigate();
   const [isPopupVisible, setPopupVisible] = useState(false);
   const popupRef = useRef(null);
+  const setAccessToken = useAccessTokenStore((state) => state.setAccessToken);
+  const accessToken = useAccessTokenStore((state) => state.accessToken);
 
   useEffect(() => {
     const handleOutsideClick = (event) => {
@@ -48,22 +51,23 @@ const Header = () => {
     setPopupVisible(false);
   };
 
-  // api 폴더 생성되면 멤버스에 넣어주기
   const handleConfirm = async () => {
     try {
-      const accessToken = localStorage.getItem("accessToken");
-      await axios.delete("/api/logouts", {
-        headers: {
-          Authorization: accessToken,
-        },
-      });
-      localStorage.removeItem("accessToken");
-      navigate("/home");
+      const response = await logout(accessToken);
+
+      if (response.status === 200) {
+        setAccessToken(null);
+      } 
+      navigate("*");
       setPopupVisible(false);
     } catch (error) {
-      console.log(error);
+      if (error === 400) {
+        alert("실패");
+      }
     }
   };
+
+  console.log(accessToken);
 
   const handlePopupClick = () => {
     // 팝업 영역 클릭 시 이벤트 전파를 막지 않음

--- a/client/src/components/Header/Header.jsx
+++ b/client/src/components/Header/Header.jsx
@@ -58,7 +58,7 @@ const Header = () => {
       if (response.status === 200) {
         setAccessToken(null);
       } 
-      navigate("*");
+      navigate("/home");
       setPopupVisible(false);
     } catch (error) {
       if (error === 400) {
@@ -67,7 +67,6 @@ const Header = () => {
     }
   };
 
-  console.log(accessToken);
 
   const handlePopupClick = () => {
     // 팝업 영역 클릭 시 이벤트 전파를 막지 않음


### PR DESCRIPTION
- 기존 로컬 스토리지에서 액세스 토큰 삭제하는 부분에서 스토어에서 액세스 토큰을 null 로 변경하도록 수정
- 로그아웃 api -> logout.api.js 로 분리 완료